### PR TITLE
feat: Pass Env Variables to CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ parameters:
 * `project (string, required)`: Specifies the GitLab project identifier to be included in the URL.
 * `token (string, required)`: Specifies the access token for the project.
 * `ref (string, required)`: Specifies the branch or label for the project.
+* `variables (object, optional)`: Specifies the environment variables that should be created for the CI/CD process.
 * `options (object, required)`: Must specify the options object that is passed to the makefile function when it is invoked by the utility.
 
 ### 3.2 - Helper Functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cross-platform-build",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Cross platform build tool aimed at replacing nmake and gnu make with a more flexible solution.",
   "main": "src/index.js",
   "scripts": {

--- a/src/GitlabTriggerPipeline.js
+++ b/src/GitlabTriggerPipeline.js
@@ -9,6 +9,7 @@ const Axios = require("axios").default;
  * @property {string} token Specifies the access token to trigger the pipeline
  * @property {string} ref Specifies the branch or tag of the project to build
  * @param {object} options Must specify the options that were passed to the makefile function.
+ * @param {object?} variables Specifies the colllection of environment variables that will be passed to the CI/CD environment
  */
 /**
  * Triggers a pipeline on a GitLab project 
@@ -21,6 +22,7 @@ async function gitlab_trigger_pipeline({
    project,
    token,
    ref,
+   variables = {},
    options
 }) {
    const rtn = await Target.target({
@@ -31,7 +33,8 @@ async function gitlab_trigger_pipeline({
          return new Promise((accept, reject) => {
             const data = {
                token,
-               ref
+               ref,
+               variables
             };
             const url = `https://gitlab.com/api/v4/projects/${project}/trigger/pipeline`;
             Axios.postForm(url, data).then(() => {


### PR DESCRIPTION
* feat: Added an optional parameter to `gitlab_trigger_pipeline()` to specify the environment variables that should be passed to the CI/CD process.
