### PR TITLE
feat: New Target Type to Generate C Source with Encrypted Secrets

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+_assets/secret.h

--- a/README.md
+++ b/README.md
@@ -3,6 +3,36 @@
 High level build platform that can be used to generate build targets with dependencies.  The build tool,
 when invoked, will look for a file, makefile.js, that should export a single async function that will make calls to various platform functions that will generate targets.
 
+- [1 - Installing cross-platform-build](#1-installing-cross-platform-build)
+- [2 - Running cross-platform-build](#2-running-cross-platform-build)
+- [3 - Creating a Makefile](#3-creating-a-makefile)
+  - [3.1 - Target Types](#31-target-types)
+    - [3.1.1 - target()](#311-target)
+    - [3.1.2 - execute()](#312-execute)
+    - [3.1.3 - make\_cdecl()](#313-make_cdecl)
+    - [3.1.4 - msbuild()](#314-msbuild)
+    - [3.1.5 - http\_request()](#315-http_request)
+    - [3.1.6 - pull\_docker\_container()](#316-pull_docker_container)
+    - [3.1.7 - docker\_container()](#317-docker_container)
+    - [3.1.8 mk\_dir()](#318-mk_dir)
+    - [3.1.9 copy\_file()](#319-copy_file)
+    - [3.1.10 rsync()](#3110-rsync)
+    - [3.1.11 pdf\_latex()](#3111-pdf_latex)
+    - [3.1.12 - svg\_to\_ico()](#3112-svg_to_ico)
+    - [3.1.13 - svg\_to\_png()](#3113-svg_to_png)
+    - [3.1.14 rm()](#3114-rm)
+    - [3.1.15 wait\_for\_sync()](#3115-wait_for_sync)
+    - [3.1.16 rename()](#3116-rename)
+    - [3.1.17 `write_file()`](#3117-write_file)
+    - [3.1.18 `write_c_header()`](#3118-write_c_header)
+    - [3.1.19 `gitlab_trigger_pipeline`](#3119-gitlab_trigger_pipeline)
+    - [3.1.20 `touch()`](#3120-touch)
+    - [3.1.21 `make_csecrets()`](#3121-make_csecrets)
+  - [3.2 - Helper Functions](#32-helper-functions)
+    - [3.2.1 - pick\_dir\_targets()](#321-pick_dir_targets)
+    - [3.2.2 - subdir()](#322-subdir)
+    - [3.2.3 - Logger()](#323-logger)
+
 ## 1 - Installing cross-platform-build
 
 The easiest way to use the cross-platform build package is to install it globally:
@@ -357,6 +387,25 @@ this target is executed
 * `options` (object, required): must specify the `options` object passed to the makefile function when 
 it is invoked by the utility.
 
+#### 3.1.21 `make_csecrets()`
+
+This function generates C or C++ code from a `secrets` object which is interpreted as map of strings that will
+declare the encrypted version of those keys using `AES-256-GCM`.  The purpose of the generated structure is
+to allow secrets to be included in C/C++ application source but not reveal the plain text of those secrets.
+This function expects the following parameters:
+
+* `name` (string, required): specifies the name for the new target
+* `depends` (string[], required): specifies the targets that should bn built before this target
+* `output` (string, required): specifies the name of the source code file that will be generated
+* `variable_name` (string, required): specifies the name that will be assigned in the source file to the generated
+   structure.  This name will also form the basis of the structure declarations that are generated as well.
+* `namespaces` (string[], optional): specifies the collection of C++ namespaces in which the structure types and 
+   structure variable.  If empty, the declarations will be global variables.
+* `should_write` (function<bool>, optional): optional function that will be evaluated when the target is built
+   and will control whether the asurce file will be generated.
+* `secrets` (object, required): specifies the secrets that will be encrypted in the generated file.  Each property
+   will be interpreted as a string.
+* `options` (object, required): should specify the options structure passed to the makefile entry point.
 
 ### 3.2 - Helper Functions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cross-platform-build",
-  "version": "1.9.3",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cross-platform-build",
-      "version": "1.9.3",
+      "version": "1.11.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cross-platform-build",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Cross platform build tool aimed at replacing nmake and gnu make with a more flexible solution.",
   "main": "src/index.js",
   "scripts": {

--- a/src/MakeCSecrets.js
+++ b/src/MakeCSecrets.js
@@ -1,0 +1,161 @@
+const target = require("./Target.js");
+const fs = require("node:fs");
+const crypto = require("node:crypto");
+
+function format_namespaces(namespaces) {
+   const rtn = {
+      declare_prefix: [],
+      declare_postfix: [],
+      pad: ""
+   };
+   namespaces.forEach((namespace) => {
+      const pad = rtn.pad;
+      rtn.pad += "   ";
+      rtn.declare_prefix.push(`${pad}namespace ${namespace} {`);
+      rtn.declare_postfix.push(`${pad}};`);
+   });
+   rtn.declare_postfix.reverse();
+   return rtn;
+}
+
+function make_key(length) {
+   return crypto.randomBytes(length);
+}
+
+function format_binary(key, as_string) {
+   const rtn = [];
+   if(as_string) {
+      rtn.push("\"");
+      for(let i = 0; i < key.length; ++i) {
+         if(key[i] <= 0x0f)
+            rtn.push("\\x0");
+         else
+            rtn.push("\\x");
+         rtn.push(key[i].toString(16));
+      }     
+      rtn.push("\"");
+   }
+   else {
+      rtn.push("{ ");
+      for(let i = 0; i < key.length; ++i) {
+         if(i > 0)
+            rtn.push(", ");
+         rtn.push(`0x${key[i].toString(16)}`);
+      }
+      rtn.push(" }");
+      
+   }
+   return rtn.join("");
+}
+
+/**
+ * @typedef EncryptRtnType Specifies the structure of data that should be returned by the encrypt() function
+ * @property {Buffer} encrypted specifies the encrypted buffer
+ * @property {Buffer} iv specifies the initialisation vector
+ */
+/**
+ * Implements the encryption algorithm 
+ * @param {string} name specifies the name of the secret to encrypt
+ * @param {Buffer} key specifies the key to be used for encryption
+ * @param {string} secret specifies the secret to encrypt
+ * @return {EncryptRtnType} returns the encrypted secret in a Buffer.
+ */
+function encrypt(name, key, secret) {
+   const iv = crypto.randomBytes(16);
+   const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+   const encrypted = Buffer.concat([ cipher.update(secret), cipher.final() ]);
+   return {
+      encrypted: encrypted,
+      iv: iv
+   };
+}
+
+/**
+ * @typedef MakeCSecretsArgs 
+ * @property {string} name specifies the name of the target
+ * @property {string[]} depends specifies the collection of targets on which this target will
+ * depend.
+ * @property {string} output specifies the name of the C source file generated
+ * @property {string} variable_name specifies the name of the secrets structure that will be generated
+ * and, indirectly, the type names for the structure types
+ * @property {string[]} namespaces optionally specifies the collection of namespaces in which the 
+ * c++ code will be generated
+ * @property {function<bool>} should_write optionally specifies a function that will be called when the target
+ * executes that will determine whether the file should be generated.
+ * @property {object} secrets specifies the secrets to encode
+ * @property {object} options specifies the options structure passed to the makefile entry point
+ */
+/**
+ * Defines a task type that will generate the c declarations for a secrets structure from the provided
+ * map of secrets and an encryption function.  
+ * 
+ * @return {object} returns the object created to generate the output
+ * @param {MakeCSecretsArgs} args specifies the argument for this target
+ * 
+ */
+async function make_csecrets({
+   name,
+   depends = [],
+   output,
+   variable_name,
+   secrets,
+   namespaces = [],
+   should_write = async () => true,
+   options
+}) {
+   const rtn = await target.target({
+      name,
+      depends,
+      options,
+      action: async () => {
+         // if should_write returns false, we can abort the target immediately
+         if(!await should_write())
+            return true;
+
+         // we will store the lines to be output as an array of strings that will be concatenated with line endings
+         // ("\r\n") before being output to the file
+         const key = make_key(32);
+         const namespace = format_namespaces(namespaces);
+         const secret_keys = Object.keys(secrets);
+         const formatted_secrets = secret_keys.map((name) => {
+            const encrypted = encrypt(name, key, secrets[name]);
+            const rtn = [
+               `${namespace.pad}     { `,
+               `${namespace.pad}        "${name}", ${secrets[name].length},`,
+               `${namespace.pad}        ${format_binary(encrypted.encrypted, true)},`,
+               `${namespace.pad}        ${format_binary(encrypted.iv, true)}`,
+               `${namespace.pad}     },`
+            ];
+            return rtn.join("\r\n");
+         });
+         const file_contents = [
+            ...namespace.declare_prefix,
+            `${namespace.pad}struct ${variable_name}_entry_type {`,
+            `${namespace.pad}   char const *name;`,
+            `${namespace.pad}   size_t const length;`,
+            `${namespace.pad}   unsigned const char *secret;`,
+            `${namespace.pad}   unsigned const char *iv;`,
+            `${namespace.pad}};`,
+            `${namespace.pad}struct ${variable_name}_type {`,
+            `${namespace.pad}   unsigned char const key[${key.length}];`,
+            `${namespace.pad}   ${variable_name}_entry_type const entries[${secret_keys.length}];`,
+            `${namespace.pad}} const ${variable_name} = {`,
+            `${namespace.pad}   ${format_binary(key, false)},`,
+            `${namespace.pad}   {`,
+            ...formatted_secrets,
+            `${namespace.pad}   }`,
+            `${namespace.pad}};`,
+            ...namespace.declare_postfix
+         ];
+
+         // we can noow attempt to write the formatted contents to the output file.
+         await fs.promises.writeFile(output, file_contents.join("\r\n"));
+         return true;
+      }
+   });
+   return rtn;
+}
+
+module.exports = {
+   make_csecrets
+};

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const Rename = require("./Rename");
 const WriteFile = require("./WriteFile");
 const GitlabTriggerPipeline = require("./GitlabTriggerPipeline");
 const Touch = require("./Touch");
+const MakeCSecrets = require("./MakeCSecrets");
 
 module.exports = {
    Target,
@@ -45,6 +46,7 @@ module.exports = {
    rename: Rename.rename,
    write_file: WriteFile.write_file,
    write_c_header: WriteFile.write_c_header,
-   touch: Touch.touch
+   touch: Touch.touch,
+   make_csecrets: MakeCSecrets.make_csecrets
 };
 

--- a/src/makefile.js
+++ b/src/makefile.js
@@ -1,6 +1,8 @@
 const MakeCDecl = require("./MakeCDecl");
 const PickDirTargets = require("./PickDirTargets");
 const WaitForSync = require("./WaitForSync");
+const MakeCSecrets = require("./MakeCSecrets");
+const path = require("node:path");
 
 module.exports = async function(options) {
    const match_js = /\.js$/;
@@ -25,6 +27,20 @@ module.exports = async function(options) {
       reference: "WaitForSync.js",
       target: "WaitForSync.js.h",
       delay_after: 10,
+      options
+   });
+   await MakeCSecrets.make_csecrets({
+      name: "src/make-secrets",
+      depends: [],
+      output: path.join("..", "_assets", "secrets.h"),
+      variable_name: "my_secrets",
+      namespaces: [ "Csi", "SigningSecrets" ],
+      secrets: {
+         low: "low",
+         medium: "medium",
+         high: "high",
+         top: "top"
+      },
       options
    });
 };


### PR DESCRIPTION
* feat: added a new target type function, `make_csecrets()` that can be used to generate a set of C/C++ source code that contains encrypted versions of a collection of specified secrets.